### PR TITLE
only add value to hash if attr_element hash text

### DIFF
--- a/lib/omniauth/strategies/wsfed/auth_callback.rb
+++ b/lib/omniauth/strategies/wsfed/auth_callback.rb
@@ -72,10 +72,11 @@ module OmniAuth
                   value = []
                   attr_element.elements.each { |element| value << element.text }
                 else
-                  value = attr_element.elements.first.text.lstrip.rstrip
+                  value = attr_element.elements.first.text
+                  value = value.lstrip.rstrip if !value.nil?
                 end
 
-                result[name] = value
+                result[name] = value if !value.nil?
               end
             end
           end


### PR DESCRIPTION
The gem was raising an exception when in the callback there are elements without content, like:

<pre>&lt;Element /&gt;</pre>


In those cases the following is raised:

undefined method `lstrip' for nil:NilClass

Regards.
