### PR TITLE
Use OmniAuth's callback_url as default reply URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ relationship. This option or `:idp_cert` must be present.
 IdP must issue a secure token. **Required**
 
 * `:reply` - The reply-to URL in your application for which a WSFed response should be
-posted. **Required**
+posted. Defaults to the OmniAuth callback URL. **Optional**
 
 * `:id_claim` - Name of the authentication claim that you want to use as OmniAuth's
 **uid** property.

--- a/lib/omniauth/strategies/wsfed.rb
+++ b/lib/omniauth/strategies/wsfed.rb
@@ -14,7 +14,9 @@ module OmniAuth
 
       # Issues passive WS-Federation redirect for authentication...
       def request_phase
-        auth_request = OmniAuth::Strategies::WSFed::AuthRequest.new(options, :whr => @request.params['whr'])
+        settings = options.dup
+        settings[:reply] ||= callback_url
+        auth_request = OmniAuth::Strategies::WSFed::AuthRequest.new(settings, :whr => @request.params['whr'])
         redirect(auth_request.redirect_url)
       end
 

--- a/spec/omniauth/strategies/wsfed_spec.rb
+++ b/spec/omniauth/strategies/wsfed_spec.rb
@@ -105,4 +105,26 @@ describe OmniAuth::Strategies::WSFed, :type => :strategy do
   end
 end
 
+describe OmniAuth::Strategies::WSFed, :type => :strategy do
+  include OmniAuth::Test::StrategyTestCase
 
+  let(:home_realm_discovery) { '/auth/wsfed/home_realm_discovery' }
+  let(:wsfed_settings) do
+    {
+      :issuer => 'https://c4sc.accesscontrol.windows.net.com/v2/wsfederation',
+      :realm  => 'http://example.com/rp',
+    }
+  end
+  let(:strategy) { [OmniAuth::Strategies::WSFed, wsfed_settings] }
+  let(:home_realm) { 'http://identity.c4sc.com' }
+
+  describe 'request_phase: GET /auth/wsfed' do
+    context 'without :reply setting' do
+      it 'should use the default callback_url'  do
+        get 'auth/wsfed'
+        last_response.status.should   == 302
+        last_response.location.should include("wreply=http%3A%2F%2Fexample.org%2Fauth%2Fwsfed%2Fcallback")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is similiar to how other omniauth gems implement this.