### PR TITLE
SAML Tokens: Guards against attributes with nil values

### DIFF
--- a/lib/omniauth/strategies/wsfed/saml_1_token.rb
+++ b/lib/omniauth/strategies/wsfed/saml_1_token.rb
@@ -31,7 +31,7 @@ module OmniAuth
                 value = []
                 attr_element.elements.each { |element| value << element.text }
               else
-                value = attr_element.elements.first.text.lstrip.rstrip
+                value = attr_element.elements.first.text.to_s.lstrip.rstrip
               end
 
               result[name] = value

--- a/lib/omniauth/strategies/wsfed/saml_2_token.rb
+++ b/lib/omniauth/strategies/wsfed/saml_2_token.rb
@@ -31,7 +31,7 @@ module OmniAuth
                 value = []
                 attr_element.elements.each { |element| value << element.text }
               else
-                value = attr_element.elements.first.text.lstrip.rstrip
+                value = attr_element.elements.first.text.to_s.lstrip.rstrip
               end
 
               result[name] = value


### PR DESCRIPTION
saml tokens cannot handle nil values currently and will throw an error when coming across one. This pull request ensures the value of `#text` is a string. 