### PR TITLE
README: Use SVG for badge icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # OmniAuth WS-Fed #
 
-[![Gem Version](https://badge.fury.io/rb/omniauth-wsfed.png)](http://badge.fury.io/rb/omniauth-wsfed)
-[![Code Climate](https://codeclimate.com/github/kbeckman/omniauth-wsfed.png)](https://codeclimate.com/github/kbeckman/omniauth-wsfed)
-[![Build Status](https://travis-ci.org/kbeckman/omniauth-wsfed.png?branch=development)](https://travis-ci.org/kbeckman/omniauth-wsfed)
+[![Gem Version](https://badge.fury.io/rb/omniauth-wsfed.svg)](http://badge.fury.io/rb/omniauth-wsfed)
+[![Code Climate](https://codeclimate.com/github/kbeckman/omniauth-wsfed.svg)](https://codeclimate.com/github/kbeckman/omniauth-wsfed)
+[![Build Status](https://travis-ci.org/kbeckman/omniauth-wsfed.svg?branch=development)](https://travis-ci.org/kbeckman/omniauth-wsfed)
 
 The OmniAuth-WSFed authentication strategy can be used with the following technologies
-under scenarios requiring the [WS-Federation protocol](﻿http://msdn.microsoft.com/en-us/library/bb498017.aspx)
+under scenarios requiring the [WS-Federation protocol](http://msdn.microsoft.com/en-us/library/bb498017.aspx)
 for authentication. These services are typically used for Identity Federation and Single
 Sign-On across large organizations or authentication domains.
 


### PR DESCRIPTION
This PR makes the README display badges as SVG, which is clearer to read.

It also removes a wrong character in a documentation link to the MSDN overview article about WS FED.