### PR TITLE
AuthRequest#wsfed_signin_request query string build fixed.

### DIFF
--- a/lib/omniauth/strategies/wsfed/auth_request.rb
+++ b/lib/omniauth/strategies/wsfed/auth_request.rb
@@ -27,19 +27,23 @@ module OmniAuth
         end
 
         def wsfed_signin_request
-          wa      = SIGNIN_PARAM
-          wtrealm = url_encode(strategy_settings[:realm])
-          wreply  = url_encode(strategy_settings[:reply])
-          wct     = url_encode(Time.now.utc)
-          whr     = url_encode(args[:whr])
+          new_issuer_params = {
+            wa:      SIGNIN_PARAM,
+            wtrealm: url_encode(strategy_settings[:realm]),
+            wreply:  url_encode(strategy_settings[:reply]),
+            wct:     url_encode(Time.now.utc),
+            wctx:    nil,
+          }
 
-          query_string = "?wa=#{wa}&wtrealm=#{wtrealm}&wreply=#{wreply}&wctx=#{}&wct=#{wct}"
+          whr = url_encode(args[:whr])
 
-          unless whr.nil? or whr.empty?
-            query_string = "#{query_string}&whr=#{whr}"
-          end
+          new_issuer_params[:whr] = whr if whr.present?
 
-          strategy_settings[:issuer] + query_string
+          issuer_url        = URI.parse(strategy_settings[:issuer])
+          issuer_url_params = issuer_url.query.present? ? Hash[CGI.parse(issuer_url.query).map{ |key,values| [ key.to_sym, values[0] || true ] } ] : {}
+          issuer_url.query  = URI.encode_www_form(issuer_url_params.merge(new_issuer_url_params))
+
+          issuer_url.to_s
         end
 
       end


### PR DESCRIPTION
Issuer URL build changed to concat params correctly, as it was always doing it with "?", even if the URL already had it.

Without this fix, it generates query strings such as "issuer_url/**?param1=abc?**param2=123", ending up with some of them missing.